### PR TITLE
Ignore node_modules directory with lint and format

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
-find . -type f | grep -e '.*\.cc' -e '.*\.h' | xargs clang-format -i --sort-includes -style=google;
-find . -type f | grep -e '.py$' | xargs python -m yapf -i --style google;
+find . -type f | grep -e '.*\.cc' -e '.*\.h' | grep -v "node_modules" | xargs clang-format -i --sort-includes -style=google;
+find . -type f | grep -e '.py$' | grep -v "node_modules" | xargs python -m yapf -i --style google;
 bazelisk run :buildifier

--- a/lint.sh
+++ b/lint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
-find . -type f | grep -e '.*\.cc' -e '.*\.h' | xargs clang-format --sort-includes -style=google -Werror -n;
-find . -type f | grep -e '.py$' | xargs python -m yapf --style google -q;
+find . -type f | grep -e '.*\.cc' -e '.*\.h' | grep -v 'node_modules' | xargs clang-format --sort-includes -style=google -Werror -n;
+find . -type f | grep -e '.py$' | grep -v 'node_modules' | xargs python -m yapf --style google -q;
 bazelisk test :buildifier_test


### PR DESCRIPTION
Prior to this, the linter would fail because of C++ files found in
the node_modules directory.