### PR TITLE
Fix TrainingSetDef shorthand

### DIFF
--- a/ff/serving/provider/offline.go
+++ b/ff/serving/provider/offline.go
@@ -77,8 +77,10 @@ func (def *TrainingSetDef) check() error {
 	if len(def.Features) == 0 {
 		return errors.New("training set must have atleast one feature")
 	}
-	for _, feature := range def.Features {
-		if err := feature.check(Feature); err != nil {
+	for i := range def.Features {
+		// We use features[i] to make sure that the Type value is updated to
+		// Feature if it's unset.
+		if err := def.Features[i].check(Feature); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
A TrainingSetDef's Features and Labels may not have their types set (since they are implied). This makes it more natural to manually write TrainingSetDefs. Prior to this PR, it wasn't working. This fixes the bug and adds a test for it.