### PR TITLE
Adds ServeOnListener to Metadata Server

### DIFF
--- a/ff/serving/metadata/metadata.go
+++ b/ff/serving/metadata/metadata.go
@@ -786,6 +786,7 @@ type MetadataServer struct {
 	lookup     ResourceLookup
 	address    string
 	grpcServer *grpc.Server
+	listener   net.Listener
 	pb.UnimplementedMetadataServer
 }
 
@@ -820,21 +821,36 @@ func (serv *MetadataServer) Serve() error {
 	if err != nil {
 		return err
 	}
+	return serv.ServeOnListener(lis)
+}
+
+func (serv *MetadataServer) ServeOnListener(lis net.Listener) error {
+	serv.listener = lis
 	grpcServer := grpc.NewServer()
 	pb.RegisterMetadataServer(grpcServer, serv)
 	serv.grpcServer = grpcServer
-	serv.Logger.Infow("Server starting", "Address", serv.address)
+	serv.Logger.Infow("Server starting", "Address", serv.listener.Addr().String())
 	return grpcServer.Serve(lis)
 }
 
-func (serv *MetadataServer) GracefulStop() {
+func (serv *MetadataServer) GracefulStop() error {
+	if serv.grpcServer == nil {
+		return fmt.Errorf("Server not running")
+	}
 	serv.grpcServer.GracefulStop()
 	serv.grpcServer = nil
+	serv.listener = nil
+	return nil
 }
 
-func (serv *MetadataServer) Stop() {
+func (serv *MetadataServer) Stop() error {
+	if serv.grpcServer == nil {
+		return fmt.Errorf("Server not running")
+	}
 	serv.grpcServer.Stop()
 	serv.grpcServer = nil
+	serv.listener = nil
+	return nil
 }
 
 type StorageProvider interface {


### PR DESCRIPTION
In some cases (like testing) it'd be nice to provide our own listener to serve metadata on.