### PR TITLE
Add update status and convert proto time field to proto timestamp

### DIFF
--- a/ff/serving/metadata/client.go
+++ b/ff/serving/metadata/client.go
@@ -1088,7 +1088,7 @@ func (stringer protoStringer) String() string {
 }
 
 type createdGetter interface {
-	GetCreated() timestamppb.Timestamp
+	GetCreated() *timestamppb.Timestamp
 }
 
 type createdFn struct {
@@ -1097,9 +1097,6 @@ type createdFn struct {
 
 func (fn createdFn) Created() time.Time {
 	t := fn.getter.GetCreated().AsTime()
-	if err != nil {
-		panic(err)
-	}
 	return t
 }
 

--- a/ff/serving/metadata/client.go
+++ b/ff/serving/metadata/client.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
-	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	tspb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type NameVariant struct {
@@ -94,7 +94,7 @@ func (client *Client) SetUpdateStatus(ctx context.Context, resID ResourceID, sch
 	nameVariant := pb.NameVariant{Name: resID.Name, Variant: resID.Variant}
 	resourceID := pb.ResourceID{Resource: &nameVariant, ResourceType: resID.Type.Serialized()}
 	resourceStatus := pb.ResourceStatus{Status: pb.ResourceStatus_Status(status), ErrorMessage: errorMessage}
-	pbTimestamp := timestamppb.New(timestamp)
+	pbTimestamp := tspb.New(timestamp)
 	pbSchedule := pb.Schedule{Schedule: schedule}
 	updateStatus := pb.UpdateStatus{LastUpdated: pbTimestamp, Schedule: &pbSchedule, UpdateStatus: &resourceStatus}
 	statusRequest := pb.SetUpdateStatusRequest{ResourceId: &resourceID, Status: &updateStatus}
@@ -1088,7 +1088,7 @@ func (stringer protoStringer) String() string {
 }
 
 type createdGetter interface {
-	GetCreated() *timestamppb.Timestamp
+	GetCreated() *tspb.Timestamp
 }
 
 type createdFn struct {

--- a/ff/serving/metadata/client.go
+++ b/ff/serving/metadata/client.go
@@ -15,7 +15,6 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/protobuf"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )

--- a/ff/serving/metadata/etcd.go
+++ b/ff/serving/metadata/etcd.go
@@ -114,7 +114,7 @@ func (config EtcdConfig) MakeAddresses() []string {
 
 //Uses Storage Type as prefix so Resources and Jobs can be queried more easily
 func createKey(id ResourceID) string {
-	return fmt.Sprintf("%s_%s_%s", id.Type, id.Name, id.Variant)
+	return fmt.Sprintf("%s__%s__%s", id.Type, id.Name, id.Variant)
 }
 
 //Puts K/V into ETCD
@@ -313,11 +313,11 @@ func (lookup etcdResourceLookup) Has(id ResourceID) (bool, error) {
 }
 
 func GetJobKey(id ResourceID) string {
-	return fmt.Sprintf("JOB_%s_%s_%s", id.Type, id.Name, id.Variant)
+	return fmt.Sprintf("JOB__%s__%s__%s", id.Type, id.Name, id.Variant)
 }
 
 func GetScheduleJobKey(id ResourceID) string {
-	return fmt.Sprintf("SCHEDULEJOB_%s_%s_%s", id.Type, id.Name, id.Variant)
+	return fmt.Sprintf("SCHEDULEJOB__%s__%s__%s", id.Type, id.Name, id.Variant)
 }
 
 func (lookup etcdResourceLookup) HasJob(id ResourceID) (bool, error) {

--- a/ff/serving/metadata/etcd.go
+++ b/ff/serving/metadata/etcd.go
@@ -468,3 +468,17 @@ func (lookup etcdResourceLookup) SetStatus(id ResourceID, status pb.ResourceStat
 	}
 	return nil
 }
+
+func (lookup etcdResourceLookup) SetUpdateStatus(id ResourceID, status pb.UpdateStatus) error {
+	res, err := lookup.Lookup(id)
+	if err != nil {
+		return err
+	}
+	if err := res.SetUpdateStatus(status); err != nil {
+		return err
+	}
+	if err := lookup.Set(id, res); err != nil {
+		return err
+	}
+	return nil
+}

--- a/ff/serving/metadata/etcd_test.go
+++ b/ff/serving/metadata/etcd_test.go
@@ -11,7 +11,7 @@ import (
 	pb "github.com/featureform/serving/metadata/proto"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/protobuf/proto"
-	tspb "google.golang.org/protobuf/types/known/tspb"
+	tspb "google.golang.org/protobuf/types/known/timestamppb"
 	"log"
 	"reflect"
 	"testing"

--- a/ff/serving/metadata/etcd_test.go
+++ b/ff/serving/metadata/etcd_test.go
@@ -857,3 +857,37 @@ func TestEtcdConfig_ParseResource(t *testing.T) {
 		})
 	}
 }
+
+func TestCoordinatorScheduleJobSerialize(t *testing.T) {
+	resID := ResourceID{Name: "test", Variant: "foo", Type: FEATURE}
+	scheduleJob := &CoordinatorScheduleJob{
+		Attempts: 0,
+		Resource: resID,
+		Schedule: "* * * * *",
+	}
+	serialized, err := scheduleJob.Serialize()
+	if err != nil {
+		t.Fatalf("Could not serialize schedule job")
+	}
+	copyScheduleJob := &CoordinatorScheduleJob{}
+	if err := copyScheduleJob.Deserialize(serialized); err != nil {
+		t.Fatalf("Could not deserialize schedule job")
+	}
+	if copyScheduleJob != scheduleJob {
+		t.Fatalf("Information changed on serialization and deserialization for schedule job")
+	}
+}
+
+func TestGetJobKeys(t *testing.T) {
+	resID := ResourceID{Name: "test", Variant: "foo", Type: FEATURE}
+	expectedJobKey := "JOB_FEATURE_test_foo"
+	expectedScheduleJobKey := "SCHEDULEJOB_FEATURE_test_foo"
+	jobKey := GetJobKey(resID)
+	scheduleJobKey := GetScheduleJobKey(resID)
+	if jobKey != expectedJobKey {
+		t.Fatalf("Could not generate correct job key")
+	}
+	if scheduleJobKey != expectedScheduleJobKey {
+		t.Fatalf("Could not generate correct schedule job key")
+	}
+}

--- a/ff/serving/metadata/etcd_test.go
+++ b/ff/serving/metadata/etcd_test.go
@@ -11,7 +11,7 @@ import (
 	pb "github.com/featureform/serving/metadata/proto"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/protobuf/proto"
-	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	tspb "google.golang.org/protobuf/types/known/tspb"
 	"log"
 	"reflect"
 	"testing"
@@ -64,7 +64,7 @@ func Test_etcdResourceLookup_Set(t *testing.T) {
 		&featureVariantResource{&pb.FeatureVariant{
 			Name:    "featureVariantResource",
 			Type:    FEATURE_VARIANT.String(),
-			Created: timestamppb.Now(),
+			Created: tspb.Now(),
 		}},
 	}
 	tests := []struct {
@@ -134,7 +134,7 @@ func Test_etcdResourceLookup_Lookup(t *testing.T) {
 	doWant := &featureVariantResource{&pb.FeatureVariant{
 		Name:    "featureVariant",
 		Type:    FEATURE_VARIANT.String(),
-		Created: timestamppb.Now(),
+		Created: tspb.Now(),
 	}}
 
 	args1 := ResourceID{Name: "test2", Type: FEATURE}
@@ -220,7 +220,7 @@ func Test_etcdResourceLookup_Has(t *testing.T) {
 	doWant := &featureVariantResource{&pb.FeatureVariant{
 		Name:    "resource1",
 		Type:    FEATURE_VARIANT.String(),
-		Created: timestamppb.Now(),
+		Created: tspb.Now(),
 	}}
 	args1 := args{
 		ResourceID{
@@ -312,15 +312,15 @@ func Test_etcdResourceLookup_ListForType(t *testing.T) {
 	featureResources := []Resource{
 		&featureVariantResource{&pb.FeatureVariant{
 			Name:    "feature1",
-			Created: timestamppb.Now(),
+			Created: tspb.Now(),
 		}},
 		&featureVariantResource{&pb.FeatureVariant{
 			Name:    "feature2",
-			Created: timestamppb.Now(),
+			Created: tspb.Now(),
 		}},
 		&featureVariantResource{&pb.FeatureVariant{
 			Name:    "feature3",
-			Created: timestamppb.Now(),
+			Created: tspb.Now(),
 		}},
 	}
 
@@ -406,15 +406,15 @@ func Test_etcdResourceLookup_List(t *testing.T) {
 	featureResources := []Resource{
 		&featureVariantResource{&pb.FeatureVariant{
 			Name:    "feature1",
-			Created: timestamppb.Now(),
+			Created: tspb.Now(),
 		}},
 		&featureVariantResource{&pb.FeatureVariant{
 			Name:    "feature2",
-			Created: timestamppb.Now(),
+			Created: tspb.Now(),
 		}},
 		&featureVariantResource{&pb.FeatureVariant{
 			Name:    "feature3",
-			Created: timestamppb.Now(),
+			Created: tspb.Now(),
 		}},
 	}
 
@@ -501,15 +501,15 @@ func Test_etcdResourceLookup_Submap(t *testing.T) {
 	featureResources := []Resource{
 		&featureVariantResource{&pb.FeatureVariant{
 			Name:    "feature1",
-			Created: timestamppb.Now(),
+			Created: tspb.Now(),
 		}},
 		&featureVariantResource{&pb.FeatureVariant{
 			Name:    "feature2",
-			Created: timestamppb.Now(),
+			Created: tspb.Now(),
 		}},
 		&featureVariantResource{&pb.FeatureVariant{
 			Name:    "feature3",
-			Created: timestamppb.Now(),
+			Created: tspb.Now(),
 		}}}
 
 	resources := localResourceLookup{
@@ -880,8 +880,8 @@ func TestCoordinatorScheduleJobSerialize(t *testing.T) {
 
 func TestGetJobKeys(t *testing.T) {
 	resID := ResourceID{Name: "test", Variant: "foo", Type: FEATURE}
-	expectedJobKey := "JOB_FEATURE_test_foo"
-	expectedScheduleJobKey := "SCHEDULEJOB_FEATURE_test_foo"
+	expectedJobKey := "JOB__FEATURE__test__foo"
+	expectedScheduleJobKey := "SCHEDULEJOB__FEATURE__test__foo"
 	jobKey := GetJobKey(resID)
 	scheduleJobKey := GetScheduleJobKey(resID)
 	if jobKey != expectedJobKey {

--- a/ff/serving/metadata/etcd_test.go
+++ b/ff/serving/metadata/etcd_test.go
@@ -11,6 +11,7 @@ import (
 	pb "github.com/featureform/serving/metadata/proto"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"google.golang.org/protobuf/proto"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	"log"
 	"reflect"
 	"testing"
@@ -63,7 +64,7 @@ func Test_etcdResourceLookup_Set(t *testing.T) {
 		&featureVariantResource{&pb.FeatureVariant{
 			Name:    "featureVariantResource",
 			Type:    FEATURE_VARIANT.String(),
-			Created: time.Now().String(),
+			Created: timestamppb.Now(),
 		}},
 	}
 	tests := []struct {
@@ -133,7 +134,7 @@ func Test_etcdResourceLookup_Lookup(t *testing.T) {
 	doWant := &featureVariantResource{&pb.FeatureVariant{
 		Name:    "featureVariant",
 		Type:    FEATURE_VARIANT.String(),
-		Created: time.Now().String(),
+		Created: timestamppb.Now(),
 	}}
 
 	args1 := ResourceID{Name: "test2", Type: FEATURE}
@@ -219,7 +220,7 @@ func Test_etcdResourceLookup_Has(t *testing.T) {
 	doWant := &featureVariantResource{&pb.FeatureVariant{
 		Name:    "resource1",
 		Type:    FEATURE_VARIANT.String(),
-		Created: time.Now().String(),
+		Created: timestamppb.Now(),
 	}}
 	args1 := args{
 		ResourceID{
@@ -311,15 +312,15 @@ func Test_etcdResourceLookup_ListForType(t *testing.T) {
 	featureResources := []Resource{
 		&featureVariantResource{&pb.FeatureVariant{
 			Name:    "feature1",
-			Created: time.Now().String(),
+			Created: timestamppb.Now(),
 		}},
 		&featureVariantResource{&pb.FeatureVariant{
 			Name:    "feature2",
-			Created: time.Now().String(),
+			Created: timestamppb.Now(),
 		}},
 		&featureVariantResource{&pb.FeatureVariant{
 			Name:    "feature3",
-			Created: time.Now().String(),
+			Created: timestamppb.Now(),
 		}},
 	}
 
@@ -405,15 +406,15 @@ func Test_etcdResourceLookup_List(t *testing.T) {
 	featureResources := []Resource{
 		&featureVariantResource{&pb.FeatureVariant{
 			Name:    "feature1",
-			Created: time.Now().String(),
+			Created: timestamppb.Now(),
 		}},
 		&featureVariantResource{&pb.FeatureVariant{
 			Name:    "feature2",
-			Created: time.Now().String(),
+			Created: timestamppb.Now(),
 		}},
 		&featureVariantResource{&pb.FeatureVariant{
 			Name:    "feature3",
-			Created: time.Now().String(),
+			Created: timestamppb.Now(),
 		}},
 	}
 
@@ -500,15 +501,15 @@ func Test_etcdResourceLookup_Submap(t *testing.T) {
 	featureResources := []Resource{
 		&featureVariantResource{&pb.FeatureVariant{
 			Name:    "feature1",
-			Created: time.Now().String(),
+			Created: timestamppb.Now(),
 		}},
 		&featureVariantResource{&pb.FeatureVariant{
 			Name:    "feature2",
-			Created: time.Now().String(),
+			Created: timestamppb.Now(),
 		}},
 		&featureVariantResource{&pb.FeatureVariant{
 			Name:    "feature3",
-			Created: time.Now().String(),
+			Created: timestamppb.Now(),
 		}}}
 
 	resources := localResourceLookup{

--- a/ff/serving/metadata/etcd_test.go
+++ b/ff/serving/metadata/etcd_test.go
@@ -873,7 +873,7 @@ func TestCoordinatorScheduleJobSerialize(t *testing.T) {
 	if err := copyScheduleJob.Deserialize(serialized); err != nil {
 		t.Fatalf("Could not deserialize schedule job")
 	}
-	if copyScheduleJob != scheduleJob {
+	if !reflect.DeepEqual(copyScheduleJob, scheduleJob) {
 		t.Fatalf("Information changed on serialization and deserialization for schedule job")
 	}
 }

--- a/ff/serving/metadata/metadata.go
+++ b/ff/serving/metadata/metadata.go
@@ -377,6 +377,11 @@ func (this *sourceVariantResource) Notify(lookup ResourceLookup, op operation, t
 	return nil
 }
 
+func (resource *sourceVariantResource) UpdateStatus(status pb.ResourceStatus) error {
+	resource.serialized.Status = &status
+	return nil
+}
+
 func (resource *sourceVariantResource) SetUpdateStatus(status pb.UpdateStatus) error {
 	resource.serialized.UpdateStatus = &status
 	return nil
@@ -805,7 +810,7 @@ func (resource *userResource) UpdateStatus(status pb.ResourceStatus) error {
 	return nil
 }
 
-func (resource *userResource) UpdateStatus(status pb.UpdateStatus) error {
+func (resource *userResource) SetUpdateStatus(status pb.UpdateStatus) error {
 	return nil
 }
 

--- a/ff/serving/metadata/metadata.go
+++ b/ff/serving/metadata/metadata.go
@@ -17,8 +17,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const TIME_FORMAT = time.RFC1123

--- a/ff/serving/metadata/metadata.go
+++ b/ff/serving/metadata/metadata.go
@@ -18,7 +18,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const TIME_FORMAT = time.RFC1123

--- a/ff/serving/metadata/metadata.go
+++ b/ff/serving/metadata/metadata.go
@@ -377,8 +377,8 @@ func (this *sourceVariantResource) Notify(lookup ResourceLookup, op operation, t
 	return nil
 }
 
-func (resource *sourceVariantResource) UpdateStatus(status pb.UpdateStatus) error {
-	resource.serialized.Status = &status
+func (resource *sourceVariantResource) SetUpdateStatus(status pb.UpdateStatus) error {
+	resource.serialized.UpdateStatus = &status
 	return nil
 }
 
@@ -413,6 +413,10 @@ func (this *featureResource) Notify(lookup ResourceLookup, op operation, that Re
 
 func (resource *featureResource) UpdateStatus(status pb.ResourceStatus) error {
 	resource.serialized.Status = &status
+	return nil
+}
+
+func (resource *featureResource) SetUpdateStatus(status pb.UpdateStatus) error {
 	return nil
 }
 
@@ -480,6 +484,11 @@ func (resource *featureVariantResource) UpdateStatus(status pb.ResourceStatus) e
 	return nil
 }
 
+func (resource *featureVariantResource) SetUpdateStatus(status pb.UpdateStatus) error {
+	resource.serialized.UpdateStatus = &status
+	return nil
+}
+
 type labelResource struct {
 	serialized *pb.Label
 }
@@ -511,6 +520,10 @@ func (this *labelResource) Notify(lookup ResourceLookup, op operation, that Reso
 
 func (resource *labelResource) UpdateStatus(status pb.ResourceStatus) error {
 	resource.serialized.Status = &status
+	return nil
+}
+
+func (resource *labelResource) SetUpdateStatus(status pb.UpdateStatus) error {
 	return nil
 }
 
@@ -578,6 +591,11 @@ func (resource *labelVariantResource) UpdateStatus(status pb.ResourceStatus) err
 	return nil
 }
 
+func (resource *labelVariantResource) SetUpdateStatus(status pb.UpdateStatus) error {
+	resource.serialized.UpdateStatus = &status
+	return nil
+}
+
 type trainingSetResource struct {
 	serialized *pb.TrainingSet
 }
@@ -609,6 +627,10 @@ func (this *trainingSetResource) Notify(lookup ResourceLookup, op operation, tha
 
 func (resource *trainingSetResource) UpdateStatus(status pb.ResourceStatus) error {
 	resource.serialized.Status = &status
+	return nil
+}
+
+func (resource *trainingSetResource) SetUpdateStatus(status pb.UpdateStatus) error {
 	return nil
 }
 
@@ -672,6 +694,11 @@ func (resource *trainingSetVariantResource) UpdateStatus(status pb.ResourceStatu
 	return nil
 }
 
+func (resource *trainingSetVariantResource) SetUpdateStatus(status pb.UpdateStatus) error {
+	resource.serialized.UpdateStatus = &status
+	return nil
+}
+
 type modelResource struct {
 	serialized *pb.Model
 }
@@ -727,6 +754,10 @@ func (resource *modelResource) UpdateStatus(status pb.ResourceStatus) error {
 	return nil
 }
 
+func (resource *modelResource) SetUpdateStatus(status pb.UpdateStatus) error {
+	return nil
+}
+
 type userResource struct {
 	serialized *pb.User
 }
@@ -771,6 +802,10 @@ func (this *userResource) Notify(lookup ResourceLookup, op operation, that Resou
 
 func (resource *userResource) UpdateStatus(status pb.ResourceStatus) error {
 	resource.serialized.Status = &status
+	return nil
+}
+
+func (resource *userResource) UpdateStatus(status pb.UpdateStatus) error {
 	return nil
 }
 
@@ -821,6 +856,10 @@ func (resource *providerResource) UpdateStatus(status pb.ResourceStatus) error {
 	return nil
 }
 
+func (resource *providerResource) SetUpdateStatus(status pb.UpdateStatus) error {
+	return nil
+}
+
 type entityResource struct {
 	serialized *pb.Entity
 }
@@ -858,6 +897,10 @@ func (this *entityResource) Notify(lookup ResourceLookup, op operation, that Res
 
 func (resource *entityResource) UpdateStatus(status pb.ResourceStatus) error {
 	resource.serialized.Status = &status
+	return nil
+}
+
+func (resource *entityResource) SetUpdateStatus(status pb.UpdateStatus) error {
 	return nil
 }
 

--- a/ff/serving/metadata/metadata.go
+++ b/ff/serving/metadata/metadata.go
@@ -18,7 +18,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
-	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	tspb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const TIME_FORMAT = time.RFC1123
@@ -319,7 +319,7 @@ func (resource *sourceResource) UpdateStatus(status pb.ResourceStatus) error {
 }
 
 func (resource *sourceResource) SetUpdateStatus(status pb.UpdateStatus) error {
-	return nil
+	return fmt.Errorf("not implemented")
 }
 
 type sourceVariantResource struct {
@@ -422,7 +422,7 @@ func (resource *featureResource) UpdateStatus(status pb.ResourceStatus) error {
 }
 
 func (resource *featureResource) SetUpdateStatus(status pb.UpdateStatus) error {
-	return nil
+	return fmt.Errorf("not implemented")
 }
 
 type featureVariantResource struct {
@@ -529,7 +529,7 @@ func (resource *labelResource) UpdateStatus(status pb.ResourceStatus) error {
 }
 
 func (resource *labelResource) SetUpdateStatus(status pb.UpdateStatus) error {
-	return nil
+	return fmt.Errorf("not implemented")
 }
 
 type labelVariantResource struct {
@@ -636,7 +636,7 @@ func (resource *trainingSetResource) UpdateStatus(status pb.ResourceStatus) erro
 }
 
 func (resource *trainingSetResource) SetUpdateStatus(status pb.UpdateStatus) error {
-	return nil
+	return fmt.Errorf("not implemented")
 }
 
 type trainingSetVariantResource struct {
@@ -760,7 +760,7 @@ func (resource *modelResource) UpdateStatus(status pb.ResourceStatus) error {
 }
 
 func (resource *modelResource) SetUpdateStatus(status pb.UpdateStatus) error {
-	return nil
+	return fmt.Errorf("not implemented")
 }
 
 type userResource struct {
@@ -811,7 +811,7 @@ func (resource *userResource) UpdateStatus(status pb.ResourceStatus) error {
 }
 
 func (resource *userResource) SetUpdateStatus(status pb.UpdateStatus) error {
-	return nil
+	return fmt.Errorf("not implemented")
 }
 
 type providerResource struct {
@@ -862,7 +862,7 @@ func (resource *providerResource) UpdateStatus(status pb.ResourceStatus) error {
 }
 
 func (resource *providerResource) SetUpdateStatus(status pb.UpdateStatus) error {
-	return nil
+	return fmt.Errorf("not implemented")
 }
 
 type entityResource struct {
@@ -906,7 +906,7 @@ func (resource *entityResource) UpdateStatus(status pb.ResourceStatus) error {
 }
 
 func (resource *entityResource) SetUpdateStatus(status pb.UpdateStatus) error {
-	return nil
+	return fmt.Errorf("not implemented")
 }
 
 type MetadataServer struct {
@@ -1044,7 +1044,7 @@ func (serv *MetadataServer) ListFeatures(_ *pb.Empty, stream pb.Metadata_ListFea
 }
 
 func (serv *MetadataServer) CreateFeatureVariant(ctx context.Context, variant *pb.FeatureVariant) (*pb.Empty, error) {
-	variant.Created = timestamppb.New(time.Now())
+	variant.Created = tspb.New(time.Now())
 	return serv.genericCreate(ctx, &featureVariantResource{variant}, func(name, variant string) Resource {
 		return &featureResource{
 			&pb.Feature{
@@ -1076,7 +1076,7 @@ func (serv *MetadataServer) ListLabels(_ *pb.Empty, stream pb.Metadata_ListLabel
 }
 
 func (serv *MetadataServer) CreateLabelVariant(ctx context.Context, variant *pb.LabelVariant) (*pb.Empty, error) {
-	variant.Created = timestamppb.New(time.Now())
+	variant.Created = tspb.New(time.Now())
 	return serv.genericCreate(ctx, &labelVariantResource{variant}, func(name, variant string) Resource {
 		return &labelResource{
 			&pb.Label{
@@ -1108,7 +1108,7 @@ func (serv *MetadataServer) ListTrainingSets(_ *pb.Empty, stream pb.Metadata_Lis
 }
 
 func (serv *MetadataServer) CreateTrainingSetVariant(ctx context.Context, variant *pb.TrainingSetVariant) (*pb.Empty, error) {
-	variant.Created = timestamppb.New(time.Now())
+	variant.Created = tspb.New(time.Now())
 	return serv.genericCreate(ctx, &trainingSetVariantResource{variant}, func(name, variant string) Resource {
 		return &trainingSetResource{
 			&pb.TrainingSet{
@@ -1140,7 +1140,7 @@ func (serv *MetadataServer) ListSources(_ *pb.Empty, stream pb.Metadata_ListSour
 }
 
 func (serv *MetadataServer) CreateSourceVariant(ctx context.Context, variant *pb.SourceVariant) (*pb.Empty, error) {
-	variant.Created = timestamppb.New(time.Now())
+	variant.Created = tspb.New(time.Now())
 	return serv.genericCreate(ctx, &sourceVariantResource{variant}, func(name, variant string) Resource {
 		return &sourceResource{
 			&pb.Source{

--- a/ff/serving/metadata/metadata_test.go
+++ b/ff/serving/metadata/metadata_test.go
@@ -1526,3 +1526,6 @@ func testFetchProvider(t *testing.T, client *Client, fetcher providerFetcher) {
 	// Don't fetch when testing, otherwise we'll get an infinite loop of fetches
 	tests.Test(t, client, []*Provider{provider}, false)
 }
+
+//iterate this for each resource with update status
+//func testSetUpdateStatus()

--- a/ff/serving/metadata/metadata_test.go
+++ b/ff/serving/metadata/metadata_test.go
@@ -1526,6 +1526,3 @@ func testFetchProvider(t *testing.T, client *Client, fetcher providerFetcher) {
 	// Don't fetch when testing, otherwise we'll get an infinite loop of fetches
 	tests.Test(t, client, []*Provider{provider}, false)
 }
-
-//iterate this for each resource with update status
-//func testSetUpdateStatus()

--- a/ff/serving/metadata/proto/metadata.proto
+++ b/ff/serving/metadata/proto/metadata.proto
@@ -4,6 +4,8 @@
 
 syntax = "proto3";
 
+import "google/protobuf/timestamp.proto";
+
 option go_package = "github.com/featureform/serving/metadata/proto";
 
 package featureform.serving.metadata.proto;
@@ -38,6 +40,8 @@ service Metadata {
     rpc CreateModel(Model) returns (Empty);
     rpc GetModels(stream Name) returns (stream Model);
     rpc SetResourceStatus(SetStatusRequest) returns (Empty);
+    rpc SetResourceUpdateStatus(SetUpdateStatusRequest) returns (Empty);
+    rpc RequestScheduleChange(ScheduleChangeRequest) returns (Empty);
 }
 
 service Api {
@@ -54,6 +58,10 @@ message Name {
     string name = 1;
 }
 
+message Schedule {
+    string schedule = 1;
+}
+
 message ResourceStatus {
     enum Status {
         NO_STATUS = 0;
@@ -64,6 +72,12 @@ message ResourceStatus {
       }
     Status status = 1;
     string error_message = 2;
+}
+
+message UpdateStatus {
+    google.protobuf.Timestamp last_updated = 1;
+    Schedule schedule = 2;
+    ResourceStatus update_status = 3;
 }
 
 enum ResourceType {
@@ -81,10 +95,24 @@ enum ResourceType {
     USER = 11;
 }
 
-message SetStatusRequest {
+message ResourceID {
     NameVariant resource = 1;
     ResourceType resource_type = 2;
-    ResourceStatus status = 3;
+}
+
+message SetStatusRequest {
+    ResourceID resource_id = 1;
+    ResourceStatus status = 2;
+}
+
+message SetUpdateStatusRequest {
+    ResourceID resource_id = 1;
+    UpdateStatus status = 2;
+}
+
+message ScheduleChangeRequest {
+    ResourceID resource_id = 1;
+    Schedule schedule = 2;
 }
 
 message NameVariant {
@@ -113,7 +141,7 @@ message FeatureVariant {
     NameVariant source = 3;
     string type = 4;
     string entity = 5;
-    string created = 6;
+    google.protobuf.Timestamp created = 6;
     string owner = 7;
     string description = 8;
     string provider = 9;
@@ -122,6 +150,7 @@ message FeatureVariant {
     oneof location {
         Columns columns = 12;
     }
+    UpdateStatus update_status = 13;
 }
 
 message Label {
@@ -138,7 +167,7 @@ message LabelVariant {
     string type = 4;
     NameVariant source = 5;
     string entity = 6;
-    string created = 7;
+    google.protobuf.Timestamp created = 7;
     string owner = 8;
     string provider = 9;
     ResourceStatus status = 10;
@@ -146,6 +175,7 @@ message LabelVariant {
     oneof location {
         Columns columns = 12;
     }
+    UpdateStatus update_status = 13;
 }
 
 message Provider {
@@ -174,11 +204,12 @@ message TrainingSetVariant {
     string variant = 2;
     string description = 3;
     string owner = 4;
-    string created = 5;
+    google.protobuf.Timestamp created = 5;
     string provider = 6;
     ResourceStatus status = 7;
     repeated NameVariant features = 8;
     NameVariant label = 9;
+    UpdateStatus update_status = 10;
 }
 
 message Entity {
@@ -225,12 +256,13 @@ message SourceVariant {
     string owner = 4;
     string description = 5;
     string provider = 6;
-    string created = 7;
+    google.protobuf.Timestamp created = 7;
     ResourceStatus status = 8;
     string table = 9;
     repeated NameVariant trainingsets = 10;
     repeated NameVariant features = 11;
     repeated NameVariant labels = 12;
+    UpdateStatus update_status = 13;
 }
 
 message Transformation {


### PR DESCRIPTION
This PR does two things:

1. Converts the string timestamps in the proto fields to google protobuf timestamps, and converts them in the metadata client methods to go format timestamps
2. Sets up methods/proto definitions for updating the schedule of a resource (for running its core job)